### PR TITLE
Fix logger initialization bug

### DIFF
--- a/src/main/java/com/zilch/payment/application/verification/PaymentVerificationScheduler.java
+++ b/src/main/java/com/zilch/payment/application/verification/PaymentVerificationScheduler.java
@@ -24,7 +24,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PaymentVerificationScheduler {
 
-    private static final Logger logger = LoggerFactory.getLogger(FraudPaymentVerifier.class);
+    private static final Logger logger = LoggerFactory.getLogger(PaymentVerificationScheduler.class);
 
     private final PaymentProvider paymentProvider;
     private final PaymentVerificationProvider paymentVerificationProvider;


### PR DESCRIPTION
## Summary
- correct logger reference in `PaymentVerificationScheduler`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883adda64e4832e9013807a1ab443fc